### PR TITLE
Implement `std::error::Error` for `?` support

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -39,10 +39,25 @@ impl From<io::Error> for Error {
     }
 }
 
+#[cfg(feature = "std")]
+impl std::error::Error for Error {}
+
 use core::fmt;
 
 impl fmt::Debug for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::BadMagic { pos, .. } => write!(f, "BadMagic {{ pos: 0x{:X} }}", pos),
+            Self::AssertFail { pos, message } => write!(f, "AssertFail at 0x{:X}: \"{}\"", pos, message),
+            Self::Io(err) => write!(f, "Io({:?})", err),
+            Self::Custom { pos, err } => write!(f, "Custom {{ pos: 0x{:X}, err: {:?} }}", pos, err),
+            _ => write!(f, "EnumErrors")
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             Self::BadMagic { pos, .. } => write!(f, "BadMagic {{ pos: 0x{:X} }}", pos),
             Self::AssertFail { pos, message } => write!(f, "AssertFail at 0x{:X}: \"{}\"", pos, message),


### PR DESCRIPTION
The `?` operator is very useful, so this implements `std::error::Error` for `binread::error::Error` to permit smoother error handling.