### PR TITLE
Make BinReaderExt call BinRead::after_parse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -252,9 +252,14 @@ pub trait BinReaderExt: Read + Seek + Sized {
             None => panic!("Must pass args, no args_default implemented")
         };
 
-        T::read_options(self, &ReadOptions{
+        let options = ReadOptions{
             endian, ..Default::default()
-        }, args)
+        };
+
+        let mut res = T::read_options(self, &options, args)?;
+        res.after_parse(self, &options, args)?;
+
+        Ok(res)
     }
 
     /// Read the given type from the reader with big endian byteorder

--- a/tests/after_parse_test.rs
+++ b/tests/after_parse_test.rs
@@ -1,0 +1,10 @@
+use binread::{BinRead, BinReaderExt, FilePtr8};
+use std::io::Cursor;
+
+#[test]
+#[allow(non_snake_case)]
+fn BinReaderExt_calls_after_parse() {
+    let test: FilePtr8<u8> = Cursor::new([0x01, 0xFF]).read_be().unwrap();
+
+    assert_eq!(*test, 0xFF);
+}


### PR DESCRIPTION
Fixes #15.

Did I go too far by adding a test for this? ~~... i just noticed that i left the fail comment in, i'll remove that with a force push real quick.~~ fixed