### PR TITLE
Fix read_bytes helper

### DIFF
--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -21,12 +21,8 @@ pub fn read_bytes<R: Read + Seek>(reader: &mut R, options: &ReadOptions, _: ()) 
         Some(x) => x,
         None => panic!("Missing count for read_bytes")
     };
-    let mut buf = Vec::with_capacity(count);
+    let mut buf = vec![0; count];
     reader.read_exact(&mut buf)?;
-
-    unsafe {
-        buf.set_len(count);
-    }
 
     Ok(buf)
 }


### PR DESCRIPTION
As it was previously written, the helper would read 0 bytes and then set the length, resulting in exposing uninitialized memory.

There are a few options for how to fix this:
 - Just zero the memory beforehand and don't bother with unsafe -- what i've currently implemented.
 - Move the call to set length to before the call to read_exact and/or init the vec w/ mem::uninitialized
 - Use MaybeUninit

I figure it's better to just avoid unsafe altogether if we can help it, but I can change the implementation on request.