### PR TITLE
Plumbing for making the try attribute call after_parse.

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -165,6 +165,28 @@ pub fn nop5<T1, T2, R: Read + Seek>(_: &mut T1, _: &mut R, _: &ReadOptions, _: T
 }
 
 #[doc(hidden)]
+/// A replacement for [`BinRead::after_parse`](BinRead::after_parse) that runs after_parse only if
+/// a value is present.
+///
+/// **Intended for internal use only**
+pub fn try_after_parse<Reader, ValueType, ArgType>(
+    item: &mut Option<ValueType>,
+    reader: &mut Reader,
+    ro: &ReadOptions,
+    args: ArgType,
+) -> BinResult<()>
+    where Reader: Read + Seek,
+          ValueType: BinRead<Args = ArgType>,
+          ArgType: Copy + 'static,
+{
+    if let Some(value) = item.as_mut() {
+        value.after_parse(reader, ro, args)?;
+    }
+
+    Ok(())
+}
+
+#[doc(hidden)]
 /// Functional wrapper to apply a [`BinRead::after_parse`](BinRead::after_parse) stand-in function
 /// to a value and then return the value if the [`after_parse`](BinRead::after_parse) function succeeds.
 ///

--- a/tests/after_parse_test.rs
+++ b/tests/after_parse_test.rs
@@ -8,3 +8,17 @@ fn BinReaderExt_calls_after_parse() {
 
     assert_eq!(*test, 0xFF);
 }
+
+
+#[derive(BinRead)]
+struct Try<BR: BinRead<Args=()>>(
+    #[br(try)]
+    Option<BR>
+);
+
+#[test]
+fn try_calls_after_parse() {
+    let test: Try<FilePtr8<u8>> = Cursor::new([0x01, 0xFF]).read_be().unwrap();
+
+    assert_eq!(*test.0.unwrap(), 0xFF)
+}


### PR DESCRIPTION
Depended on by https://github.com/jam1garner/binread_derive/pull/5. Added test will only pass with that PR merged.