### PR TITLE
Implement `BinRead` for all array lengths using const generics.

### DIFF
--- a/binread/Cargo.toml
+++ b/binread/Cargo.toml
@@ -19,6 +19,7 @@ rustversion = "1.0"
 trybuild = "1.0"
 
 [features]
+const_generics = []
 default = ["std"]
 std = []
 debug_template = ["std", "lazy_static", "binread_derive/debug_template"]

--- a/binread/Cargo.toml
+++ b/binread/Cargo.toml
@@ -10,6 +10,7 @@ readme = "../README.md"
 documentation = "https://docs.rs/binread"
 
 [dependencies]
+array-init = { version = "1.1.0", optional = true }
 binread_derive = { version = "2.0.0", path = "../binread_derive" }
 lazy_static = { version = "1.4", optional = true }
 
@@ -19,7 +20,7 @@ rustversion = "1.0"
 trybuild = "1.0"
 
 [features]
-const_generics = []
+const_generics = ["array-init"]
 default = ["std"]
 std = []
 debug_template = ["std", "lazy_static", "binread_derive/debug_template"]

--- a/binread/Cargo.toml
+++ b/binread/Cargo.toml
@@ -9,6 +9,10 @@ description = "A Rust crate for helping read structs from binary data using ✨m
 readme = "../README.md"
 documentation = "https://docs.rs/binread"
 
+[[test]]
+name = "const_generic"
+required-features = ["const_generics"]
+
 [dependencies]
 array-init = { version = "1.1.0", optional = true }
 binread_derive = { version = "2.0.0", path = "../binread_derive" }

--- a/binread/src/binread_impls.rs
+++ b/binread/src/binread_impls.rs
@@ -196,20 +196,8 @@ impl<C: Copy + 'static, B: BinRead<Args = C>, const N: usize> BinRead for [B; N]
             ..*options
         };
 
-        // Currently the only way to initialize this array with const generics
-        // without introducing additional trait bounds.
-        // https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#initializing-an-array-element-by-element
-        let mut arr: [core::mem::MaybeUninit<B>; N] =
-            unsafe { core::mem::MaybeUninit::uninit().assume_init() };
-        for elem in arr.iter_mut() {
-            *elem = core::mem::MaybeUninit::new(BinRead::read_options(reader, options, args)?);
-        }
-
-        // https://github.com/rust-lang/rust/issues/61956
-        let out_arr = unsafe { core::mem::transmute_copy::<_, [B; N]>(&arr) };
-        core::mem::forget(arr);
-
-        Ok(out_arr)
+        let arr = array_init::try_array_init(|_| BinRead::read_options(reader, options, args))?;
+        Ok(arr)
     }
 
     fn after_parse<R>(&mut self, reader: &mut R, ro: &ReadOptions, args: B::Args) -> BinResult<()>

--- a/binread/src/binread_impls.rs
+++ b/binread/src/binread_impls.rs
@@ -117,55 +117,50 @@ impl<C: Copy + 'static, B: BinRead<Args = C>> BinRead for Vec<B> {
     }
 }
 
-macro_rules! binread_array_impl {
-    ($($size:literal),*$(,)?) => {
-        $(
-            impl<C: Copy + 'static, B: BinRead<Args = C> + Default> BinRead for [B; $size] {
-                type Args = B::Args;
+impl<C: Copy + 'static, B: BinRead<Args = C>, const N: usize> BinRead for [B; N] {
+    type Args = B::Args;
 
-                fn read_options<R: Read + Seek>(reader: &mut R, options: &ReadOptions, args: Self::Args) -> BinResult<Self> {
-                    #[cfg(feature = "debug_template")]
-                    {
-                        let pos = reader.seek(SeekFrom::Current(0))?;
-                        let type_name = core::any::type_name::<B>().rsplitn(1, "::").nth(0).unwrap();
+    fn read_options<R: Read + Seek>(
+        reader: &mut R,
+        options: &ReadOptions,
+        args: Self::Args,
+    ) -> BinResult<Self> {
+        #[cfg(feature = "debug_template")]
+        {
+            let pos = reader.seek(SeekFrom::Current(0))?;
+            let type_name = core::any::type_name::<B>().rsplitn(1, "::").nth(0).unwrap();
 
-                        if let Some(name) = options.variable_name {
-                            binary_template::write_vec_named(
-                                options.endian, pos, type_name, $size, name
-                            );
-                        } else {
-                            binary_template::write_vec(options.endian, pos, type_name, $size);
-                        }
-                    }
-
-                    #[cfg(feature = "debug_template")]
-                    let options = &ReadOptions {
-                        dont_output_to_template: true,
-                        ..*options
-                    };
-
-                    let mut arr: [B; $size] = Default::default();
-                    for elem in arr.iter_mut() {
-                        *elem = BinRead::read_options(reader, options, args)?;
-                    }
-                    Ok(arr)
-                }
-
-                fn after_parse<R>(&mut self, reader: &mut R, ro: &ReadOptions, args: B::Args)-> BinResult<()>
-                    where R: Read + Seek,
-                {
-                    for val in self.iter_mut() {
-                        val.after_parse(reader, ro, args)?;
-                    }
-
-                    Ok(())
-                }
+            if let Some(name) = options.variable_name {
+                binary_template::write_vec_named(options.endian, pos, type_name, N, name);
+            } else {
+                binary_template::write_vec(options.endian, pos, type_name, N);
             }
-        )*
+        }
+
+        #[cfg(feature = "debug_template")]
+        let options = &ReadOptions {
+            dont_output_to_template: true,
+            ..*options
+        };
+
+        let mut arr: [B; N] = unsafe { core::mem::MaybeUninit::uninit().assume_init() };
+        for elem in arr.iter_mut() {
+            *elem = BinRead::read_options(reader, options, args)?;
+        }
+        Ok(arr)
+    }
+
+    fn after_parse<R>(&mut self, reader: &mut R, ro: &ReadOptions, args: B::Args) -> BinResult<()>
+    where
+        R: Read + Seek,
+    {
+        for val in self.iter_mut() {
+            val.after_parse(reader, ro, args)?;
+        }
+
+        Ok(())
     }
 }
-
-binread_array_impl!(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32);
 
 /// Internal macro to recursively implement BinRead for every size tuple given
 /// in the invocation

--- a/binread/tests/const_generic.rs
+++ b/binread/tests/const_generic.rs
@@ -1,0 +1,11 @@
+use binread::{BinRead, BinReaderExt, io::Cursor};
+
+#[test]
+fn const_generic_test() {
+    const IN: [u8; 300] = [6; 300];
+
+    let mut reader = Cursor::new(&IN);
+    let out: [u8; 300] = reader.read_be().unwrap();
+
+    assert_eq!(IN, out);
+}


### PR DESCRIPTION
This increases the minimum supported Rust version to 1.51.0.
I sadly had to introduce another unsafe statement, because:
* `Default` is only implemented for array lengths up to 32 (https://github.com/rust-lang/rust/issues/61415)
* arr_macro doesn't support const generics (https://github.com/JoshMcguigan/arr_macro/issues/2)
* Direct initialization via [T; N] adds a trait bound `BinRead: Copy`