### PR TITLE
Upgrade to array-init 2.0.0

### DIFF
--- a/binread/Cargo.toml
+++ b/binread/Cargo.toml
@@ -14,7 +14,7 @@ name = "const_generic"
 required-features = ["const_generics"]
 
 [dependencies]
-array-init = { version = "1.1.0", optional = true }
+array-init = { version = "2.0.0", optional = true }
 binread_derive = { version = "2.0.0", path = "../binread_derive" }
 lazy_static = { version = "1.4", optional = true }
 


### PR DESCRIPTION
The array-init 1.1.0 release has just been yanked.