### PR TITLE
support count option for NullString/NullWIdeString

### DIFF
--- a/binread/src/strings.rs
+++ b/binread/src/strings.rs
@@ -137,6 +137,11 @@ impl BinRead for Vec<NonZeroU16> {
         let mut values = vec![];
 
         loop {
+            if let Some(count) = options.count {
+                if values.len() >= count {
+                    return Ok(values);
+                }
+            }
             let val = <u16>::read_options(reader, options, ())?;
             if val == 0 {
                 return Ok(values);

--- a/binread/tests/derive/structs.rs
+++ b/binread/tests/derive/structs.rs
@@ -1,7 +1,7 @@
 use binread::{
     derive_binread,
     io::{Cursor, Read, Seek, SeekFrom},
-    BinRead, BinResult, FilePtr, NullString, ReadOptions,
+    BinRead, BinResult, FilePtr, NullString, ReadOptions, NullWideString,
 };
 
 #[test]
@@ -419,4 +419,25 @@ fn nullstring_count() {
     let longname = TestMan::read(&mut longname_bin).unwrap();
     assert_eq!(&*longname.name, b"Zinjanthropuses");
     assert_eq!(longname.age, 7);
+}
+
+#[test]
+fn nullwidestring_count() {
+    #[derive(BinRead)]
+    #[br(big)]
+    struct TestWideMan{
+        #[br(count = 7, pad_size_to = 14)]
+        name: NullWideString,
+        age: u16,
+    }
+
+    let mut mike_bin = Cursor::new(b"\0M\0i\0k\0e\0\0\0\0\0\0\0\x1e");
+    let mike = TestWideMan::read(&mut mike_bin).unwrap();
+    assert_eq!(mike.name.into_string(), "Mike");
+    assert_eq!(mike.age, 30);
+
+    let mut long16name_bin = Cursor::new("\0a\0a\0a\0a\0a\0a\0a\0\x64");
+    let longname = TestWideMan::read(&mut long16name_bin).unwrap();
+    assert_eq!(longname.name.into_string(), "aaaaaaa");
+    assert_eq!(longname.age, 100);
 }

--- a/binread/tests/derive/structs.rs
+++ b/binread/tests/derive/structs.rs
@@ -400,3 +400,23 @@ fn tuple_calc_temp_field() {
     // compilation would fail if it weren’t due to missing a second item
     assert_eq!(result, Test(5u32));
 }
+
+#[test]
+fn nullstring_count() {
+    #[derive(BinRead)]
+    struct TestMan{
+        #[br(count = 15, pad_size_to = 15)]
+        name: NullString,
+        age: u8,
+    }
+
+    let mut charlotte_bin = Cursor::new("Charlotte\0\0\0\0\0\0\x18");
+    let charlotte = TestMan::read(&mut charlotte_bin).unwrap();
+    assert_eq!(&*charlotte.name, b"Charlotte");
+    assert_eq!(charlotte.age, 24);
+
+    let mut longname_bin = Cursor::new("Zinjanthropuses\x07");
+    let longname = TestMan::read(&mut longname_bin).unwrap();
+    assert_eq!(&*longname.name, b"Zinjanthropuses");
+    assert_eq!(longname.age, 7);
+}

--- a/binread/tests/derive/structs.rs
+++ b/binread/tests/derive/structs.rs
@@ -405,7 +405,7 @@ fn tuple_calc_temp_field() {
 fn nullstring_count() {
     #[derive(BinRead)]
     struct TestMan{
-        #[br(count = 15, pad_size_to = 15)]
+        #[br(count = 15)]
         name: NullString,
         age: u8,
     }
@@ -426,7 +426,7 @@ fn nullwidestring_count() {
     #[derive(BinRead)]
     #[br(big)]
     struct TestWideMan{
-        #[br(count = 7, pad_size_to = 14)]
+        #[br(count = 7)]
         name: NullWideString,
         age: u16,
     }


### PR DESCRIPTION
Hi, 

`NullString` is useful, but I am concerned when reading malicious files that do not contain `'\0'`. As with `Vec<u8>`, support for the `count` option avoids reading data without limit. 

Also, we sometimes store a string in a fixed-length field and fill it with `'\0'`, but even then we want to use `NullString` to avoid unnecessary reads. For that use cases, please see the test I wrote in this PR.
